### PR TITLE
Update to MacOS 10.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ matrix:
   include:
     os: osx
     language: cpp
-    osx_image: xcode6.4
+    osx_image: xcode7.3.1
     before_install:
+    - brew update
     - brew install qt
     - brew link --force qt
     - ln -s $(brew --prefix qt)/mkspecs $(brew --prefix)/mkspecs


### PR DESCRIPTION
Fix Travis two Travis bugs:
 - Few weeks ago Travis' Homebrew was outdated and starts to require Ruby 3.5+.
 Do `brew update` before `brew install qt` as a solution.
 - MacOS 10.10 doesn't supported by Homebrew bottles (service of pre-compiled
 packages) and Qt build became too long too Travis. Switch to Travis' MacOS
 10.11 image as a solution