### PR TITLE
Fix WidgetToFitsOpenGLTransform in vertical direction

### DIFF
--- a/src/opengltransform.cpp
+++ b/src/opengltransform.cpp
@@ -111,7 +111,7 @@ void WidgetToFitsOpenGLTransform::updateTransform() const {
 	/* world unrotated */
 	matrix_.rotate(-angle_, static_cast<float>(0), static_cast<float>(0), static_cast<float>(1));
 	/* viewrect to world */
-	matrix_.translate(viewrect_.center().x(), viewrect_.center().y());
+	matrix_.translate(viewrect_.center().x(), -viewrect_.center().y());
 	matrix_.scale(viewrect_.width()/static_cast<float>(2), -viewrect_.height()/static_cast<float>(2));
 
 	/* widget pixel (0,0, w,h) to viewrect (-1,-1, 2,2)*/

--- a/test/opengltransform.cpp
+++ b/test/opengltransform.cpp
@@ -8,7 +8,10 @@ class TestWidgetToFitsOpenGLTransform: public QObject
 Q_OBJECT
 private slots:
 	void test_1x1();
+	void test_1x1a();
 	void test_1x1_rot90();
+	void test_1x1_vr2();
+	void test_1x1_vr2a();
 	void test_1x2();
 };
 
@@ -47,6 +50,46 @@ void TestWidgetToFitsOpenGLTransform::test_1x1() {
 	}
 }
 
+void TestWidgetToFitsOpenGLTransform::test_1x1a() {
+	const QSize image_size{6, 3};
+	const QSize widget_size{6, 3};
+	const QRectF view_rect{-1, -0.5, 2, 1};
+
+	OpenGLPlane p(image_size);
+	WidgetToFitsOpenGLTransform t(image_size, p.scale(), widget_size, view_rect);
+
+	{
+		auto f = t.transform(0, 0);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+	{
+		auto f = t.transform(1, 1);
+		QCOMPARE(static_cast<int>(f.x()), 1);
+		QCOMPARE(static_cast<int>(f.y()), 1);
+	}
+	{
+		auto f = t.transform(2, 2);
+		QCOMPARE(static_cast<int>(f.x()), 2);
+		QCOMPARE(static_cast<int>(f.y()), 0);
+	}
+	{
+		auto f = t.transform(0, 2);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 0);
+	}
+	{
+		auto f = t.transform(2, 0);
+		QCOMPARE(static_cast<int>(f.x()), 2);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+	{
+		auto f = t.transform(5, 0);
+		QCOMPARE(static_cast<int>(f.x()), 5);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+}
+
 void TestWidgetToFitsOpenGLTransform::test_1x1_rot90() {
 	const QSize image_size{3, 3};
 	const QSize widget_size{3, 3};
@@ -80,6 +123,71 @@ void TestWidgetToFitsOpenGLTransform::test_1x1_rot90() {
 		auto f = t.transform(2, 0);
 		QCOMPARE(static_cast<int>(f.x()), 2);
 		QCOMPARE(static_cast<int>(f.y()), 0);
+	}
+}
+
+void TestWidgetToFitsOpenGLTransform::test_1x1_vr2() {
+	const QSize image_size{4, 4};
+	const QSize widget_size{2, 2};
+	const QRectF view_rect{-1, -1, 1, 1};
+
+	OpenGLPlane p(image_size);
+	WidgetToFitsOpenGLTransform t(image_size, p.scale(), widget_size, view_rect);
+
+	{
+		auto f = t.transform(0, 0);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 3);
+	}
+	{
+		auto f = t.transform(0, 1);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+	{
+		auto f = t.transform(1, 0);
+		QCOMPARE(static_cast<int>(f.x()), 1);
+		QCOMPARE(static_cast<int>(f.y()), 3);
+	}
+	{
+		auto f = t.transform(1, 1);
+		QCOMPARE(static_cast<int>(f.x()), 1);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+}
+
+void TestWidgetToFitsOpenGLTransform::test_1x1_vr2a() {
+	const QSize image_size{8, 4};
+	const QSize widget_size{4, 2};
+	const QRectF view_rect{-1, -0.5, 1, 0.5};
+
+	OpenGLPlane p(image_size);
+	WidgetToFitsOpenGLTransform t(image_size, p.scale(), widget_size, view_rect);
+
+	{
+		auto f = t.transform(0, 0);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 3);
+	}
+	{
+		auto f = t.transform(0, 1);
+		QCOMPARE(static_cast<int>(f.x()), 0);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+	{
+		auto f = t.transform(2, 0);
+		QCOMPARE(static_cast<int>(f.x()), 2);
+		QCOMPARE(static_cast<int>(f.y()), 3);
+	}
+	{
+		auto f = t.transform(2, 1);
+		QCOMPARE(static_cast<int>(f.x()), 2);
+		QCOMPARE(static_cast<int>(f.y()), 2);
+	}
+	{
+		auto f = t.transform(3, 1);
+		QCOMPARE(static_cast<int>(f.x()), 3);
+		QCOMPARE(static_cast<int>(f.y()), 2);
 	}
 }
 


### PR DESCRIPTION
It appeared that viewrect vertical coordinates from the top to the
bottom.  When image is zoomed, the widget to image pixel transform
is incorrent. Add unit tests for WidgetToFitsOpenGLTransform and
fix the issue.