### PR TITLE
Fix uninitialized variable in OpenGLFeatures

### DIFF
--- a/src/openglfeatures.cpp
+++ b/src/openglfeatures.cpp
@@ -42,7 +42,7 @@ bool OpenGLFeatures::checkHasOpenGL21(const QOpenGLContext& opengl_context) {
 	return checkHasOpenGLHelper(opengl_context, 2, 1, mask_hasOpenGL21);
 }
 
-OpenGLFeatures::OpenGLFeatures(const QOpenGLContext& opengl_context) {
+OpenGLFeatures::OpenGLFeatures(const QOpenGLContext& opengl_context): bitmask_(0) {
 	checkHasOpenGL33(opengl_context)
 		|| checkHasOpenGL30(opengl_context)
 		|| checkHasOpenGL21(opengl_context);


### PR DESCRIPTION
Uninitialized bitmask_ leads to UB

Fixes: 04655711959b ("Add initial implementation for OpenGLFeatures and OpenGLRequiredFeatures")

Check this GUI features before merge:

- [ ] Positive and negative `BITPIX` images
- [ ] Zoom, rotate and flip
- [ ] Level control
- [ ] Color maps
- [ ] Open new image in the same window and in new window
