### PR TITLE
Do not set OpenGL 3.0 and OpenGL 2.1 flags for OpenGL 3.3

### DIFF
--- a/src/openglfeatures.cpp
+++ b/src/openglfeatures.cpp
@@ -30,8 +30,7 @@ bool OpenGLFeatures::checkHasOpenGLHelper(const QOpenGLContext& opengl_context, 
 }
 
 bool OpenGLFeatures::checkHasOpenGL33(const QOpenGLContext& opengl_context) {
-	return checkHasOpenGLHelper(opengl_context, 3, 3,
-		mask_hasOpenGL33 | mask_hasOpenGL30 | mask_hasOpenGL21);
+	return checkHasOpenGLHelper(opengl_context, 3, 3, mask_hasOpenGL33);
 }
 
 bool OpenGLFeatures::checkHasOpenGL30(const QOpenGLContext& opengl_context) {


### PR DESCRIPTION
Fixes: 04655711959b ("Add initial implementation for OpenGLFeatures and OpenGLRequiredFeatures")

Check this GUI features before merge:

- [ ] Positive and negative `BITPIX` images
- [ ] Zoom, rotate and flip
- [ ] Level control
- [ ] Color maps
- [ ] Open new image in the same window and in new window
