### PR TITLE
Fix `header_as()` behaviour.

### DIFF
--- a/include/fits.h
+++ b/include/fits.h
@@ -89,15 +89,24 @@ public:
 			return (it != headers_.end() ? it->second : def);
 		}
 		template<class T> inline T header_as(const QString& key) const {
-			QVariant v(headers_.at(key));
-			if (!v.canConvert<T>())
-				throw WrongHeaderValue(key, v.value<QString>());
+			const auto& str_v = headers_.at(key);
+
+			QVariant v(str_v);
+			if (!v.convert(qMetaTypeId<T>()))
+				throw WrongHeaderValue(key, str_v);
+
 			return v.value<T>();
 		}
 		template<class T> inline T header_as(const QString& key, const T& def) const {
-			auto it = headers_.find(key);
-			return (it != headers_.end() && QVariant(it->second).canConvert<T>() ?
-				qvariant_cast<T>(it->second) : def);
+			const auto it = headers_.find(key);
+			if (it == headers_.end())
+				return def;
+
+			QVariant v(it->second);
+			if (!v.convert(qMetaTypeId<T>()))
+				throw WrongHeaderValue(key, it->second);
+
+			return v.value<T>();
 		}
 
 		inline double bscale() const { return header_as<double>("BSCALE", 1.0); }

--- a/src/fits.cpp
+++ b/src/fits.cpp
@@ -136,28 +136,17 @@ FITS::AbstractDataUnit::AbstractDataUnit() = default;
 FITS::AbstractDataUnit::~AbstractDataUnit() = default;
 
 FITS::AbstractDataUnit* FITS::AbstractDataUnit::createFromPages(AbstractFITSStorage::Page& begin, AbstractFITSStorage::Page end, const HeaderUnit& header) {
-	bool ok = false;
-
 	const auto bitpix = header.header("BITPIX");
+	const auto naxis = header.header_as<unsigned int>("NAXIS");
 
-	const auto naxis = header.header("NAXIS").toInt(&ok);
-	if (!ok || (naxis != 0 && naxis != 2)) {
+	if (naxis == 0) {
+		return new EmptyDataUnit{};
+	} else if (naxis != 2) {
 		throw FITS::WrongHeaderValue("NAXIS", header.header("NAXIS"));
 	}
 
-	if (!naxis) {
-		return new EmptyDataUnit{};
-	}
-
-	const auto width = header.header("NAXIS1").toULongLong(&ok);
-	if (!ok) {
-		throw FITS::WrongHeaderValue("NAXIS1", header.header("NAXIS1"));
-	}
-
-	const auto height = header.header("NAXIS2").toULongLong(&ok);
-	if (!ok) {
-		throw FITS::WrongHeaderValue("NAXIS2", header.header("NAXIS2"));
-	}
+	const auto width = header.header_as<quint64>("NAXIS1");
+	const auto height = header.header_as<quint64>("NAXIS2");
 
 	return ImageDataUnit::createFromPages(begin, end, bitpix, height, width);
 }

--- a/test/fits.cpp
+++ b/test/fits.cpp
@@ -19,6 +19,10 @@ private slots:
 	void parseHeaderBscale1();
 	void parseDataUnitShape();
 	void visitDataUnit1();
+	void header1();
+	void header2();
+	void header_as1();
+	void header_as2();
 };
 
 void TestFits::pageAdvance1() {
@@ -145,6 +149,48 @@ void TestFits::visitDataUnit1() {
 		}
 	};
 	fits.data_unit().apply(test_fun{});
+}
+void TestFits::header1() {
+	QFile* file = new QFile(DATA_ROOT "/header_end.fits");
+	file->open(QIODevice::ReadOnly);
+	FITS fits(file);
+
+	QCOMPARE(fits.header_unit().header("SIMPLE"), QString("T"));
+	QVERIFY_EXCEPTION_THROWN(
+		fits.header_unit().header("NOT_EXISTS"),
+		std::out_of_range);
+}
+void TestFits::header2() {
+	QFile* file = new QFile(DATA_ROOT "/header_end.fits");
+	file->open(QIODevice::ReadOnly);
+	FITS fits(file);
+
+	QCOMPARE(fits.header_unit().header("SIMPLE"), QString("T"));
+	QCOMPARE(fits.header_unit().header("NOT_EXISTS", "Default"), QString("Default"));
+}
+void TestFits::header_as1() {
+	QFile* file = new QFile(DATA_ROOT "/header_end.fits");
+	file->open(QIODevice::ReadOnly);
+	FITS fits(file);
+
+	QCOMPARE(fits.header_unit().header_as<int>("NAXIS2"), 10);
+	QVERIFY_EXCEPTION_THROWN(
+		fits.header_unit().header_as<int>("NAXIS3"),
+		std::out_of_range);
+	QVERIFY_EXCEPTION_THROWN(
+		fits.header_unit().header_as<int>("SIMPLE"),
+		FITS::WrongHeaderValue);
+}
+void TestFits::header_as2() {
+	QFile* file = new QFile(DATA_ROOT "/header_end.fits");
+	file->open(QIODevice::ReadOnly);
+	FITS fits(file);
+
+	QCOMPARE(fits.header_unit().header_as<int>("NAXIS2"), 10);
+	QCOMPARE(fits.header_unit().header_as<int>("NAXIS3", 1), 1);
+	QVERIFY_EXCEPTION_THROWN(
+		fits.header_unit().header_as<int>("SIMPLE"),
+		FITS::WrongHeaderValue);
 }
 
 QTEST_MAIN(TestFits)


### PR DESCRIPTION
Check this GUI features before merge:

- [x] Positive and negative `BITPIX` images
- [ ] Zoom, rotate and flip
- [ ] Level control
- [ ] Color maps
- [x] Open new image in the same window and in new window
