### PR TITLE
Upgrade macOS build for Qt 5.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     os: osx
     language: cpp
-    osx_image: xcode7.3.1
+    osx_image: xcode9.4
     services: {}
     cache:
       directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,21 @@ matrix:
     - make test
     before_deploy:
     - export RELEASE_DMG_FILE=$(ls Fips-*.dmg)
-    - echo "deploying $RELEASE_DMG_FILE to GitHub Releases"
+    - echo "deploying $RELEASE_DMG_FILE"
     deploy:
-      provider: releases
-      api_key:
-        secure: I4SgyRVqHPF8f+QhyfiAXlsd98/NesRliYBap5cq1pt3/XyTREwfoYnA0rwNZ6r5oovEkQuy11tIL5k5WZuCOxqEKNqQYhLpi3Io42NX+49vS2jMTDyarE00c6YA4bLesPJQuXWWX7zdNlR6n/6MQLTL4BX5OtYfWP2xGnbzNZfkkaKUphU1rzuzPjK+y6EsglYCwSJuZMQduc+TzESQUyZ32S4mv97w3m8UTRSocIYCcNdxyuBCXMiebyprLcd2UwwrADthJTMIzRJ8298xEMfQRIoACxJou2QDhfjnLtqD1ojd+9PjPzER1zkVrwYESLiEiZLEvRCqUcbuz0iCo6LAOOrQhEOGv1yr6wXDcFeQtWjprBelTbkWyDCPktdkLRszhvrO+Q/abs+bTm+TnOt52Ax/SVC1hSF7pWfbBdzaHYeo80BaphkiF3K5bysogb1nSQjfppEY+zLfYdHl69S6RMxiF6j9RRLi8biCzUNROl/xDHvM+y5HmGoJLk04ciTIiMr7zSM4rd4m7ia3VB2i21fFA2unMgpBy5vrfTsoeonn1HSzT/TMOKFfnVClOibekAoGm66jWLqVHGVBv0D0s2MLVVJBzq855iIeFk86VTwDXJY+BZKMHqbiQ8aqoZL/97D/h4pOSFeQo975PSFoEMrMHqCpLNtc81Wci/k=
-      file: "${RELEASE_DMG_FILE}"
-      skip_cleanup: true
-      on:
-        tags: true
-        branch: master
+      - provider: releases
+        api_key:
+          secure: I4SgyRVqHPF8f+QhyfiAXlsd98/NesRliYBap5cq1pt3/XyTREwfoYnA0rwNZ6r5oovEkQuy11tIL5k5WZuCOxqEKNqQYhLpi3Io42NX+49vS2jMTDyarE00c6YA4bLesPJQuXWWX7zdNlR6n/6MQLTL4BX5OtYfWP2xGnbzNZfkkaKUphU1rzuzPjK+y6EsglYCwSJuZMQduc+TzESQUyZ32S4mv97w3m8UTRSocIYCcNdxyuBCXMiebyprLcd2UwwrADthJTMIzRJ8298xEMfQRIoACxJou2QDhfjnLtqD1ojd+9PjPzER1zkVrwYESLiEiZLEvRCqUcbuz0iCo6LAOOrQhEOGv1yr6wXDcFeQtWjprBelTbkWyDCPktdkLRszhvrO+Q/abs+bTm+TnOt52Ax/SVC1hSF7pWfbBdzaHYeo80BaphkiF3K5bysogb1nSQjfppEY+zLfYdHl69S6RMxiF6j9RRLi8biCzUNROl/xDHvM+y5HmGoJLk04ciTIiMr7zSM4rd4m7ia3VB2i21fFA2unMgpBy5vrfTsoeonn1HSzT/TMOKFfnVClOibekAoGm66jWLqVHGVBv0D0s2MLVVJBzq855iIeFk86VTwDXJY+BZKMHqbiQ8aqoZL/97D/h4pOSFeQo975PSFoEMrMHqCpLNtc81Wci/k=
+        file: "${RELEASE_DMG_FILE}"
+        skip_cleanup: true
+        on:
+          tags: true
+          branch: master
+      - provider: script
+        script: curl --upload-file ${RELEASE_DMG_FILE} https://transfer.sh/${RELEASE_DMG_FILE}
+        skip_cleanup: true
+        on:
+          all_branches: true
 
 env:
 - BASE_IMAGE_TAG=gcc8-qt511

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ if(APPLE)
 
 	list(APPEND SOURCES ${ICON_FILE} ${DOC_ICON_FILE})
 	add_executable(${TARGET} MACOSX_BUNDLE ${SOURCES})
+
+	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12)
 elseif(WIN32)
 	set(TARGET fips)
 


### PR DESCRIPTION
It should shadow the problems of #125. Now Travis build supports only macOS 10.12+

Check this GUI features before merge:

- [x] Positive and negative `BITPIX` images
- [x] Zoom, rotate and flip
- [x] Level control
- [x] Color maps
- [x] Open new image in the same window and in new window
