### PR TITLE
Fix/128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,10 @@ add_executable(test_opengltransform test/opengltransform.cpp src/abstractopenglt
 target_link_libraries(test_opengltransform Qt5::Test Qt5::Gui)
 add_test(test_opengltransform test_opengltransform)
 
+add_executable(test_utils_minmax test/utils/minmax.cpp)
+target_link_libraries(test_utils_minmax Qt5::Test)
+add_test(test_utils_minmax test_utils_minmax)
+
 add_executable(test_utils_openglrowalign test/utils/openglrowalign.cpp src/utils/openglrowalign.cpp)
 target_link_libraries(test_utils_openglrowalign Qt5::Test)
 add_test(test_utils_openglrowalign test_utils_openglrowalign)

--- a/include/abstractopenglplan.h
+++ b/include/abstractopenglplan.h
@@ -19,6 +19,10 @@
 #ifndef _ABSTRACTOPENGLPLAN_H
 #define _ABSTRACTOPENGLPLAN_H
 
+#include <algorithm>
+#include <limits>
+#include <utility>
+
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLVertexArrayObject>
@@ -29,6 +33,8 @@
 #include <fits.h>
 #include <openglplane.h>
 #include <openglshaderprogram.h>
+#include <utils/minmax.h>
+#include <utils/swapbytes.h>
 
 class AbstractOpenGLPlan:
 	protected QOpenGLFunctions {
@@ -88,21 +94,24 @@ protected:
 		const auto begin = dataunit.data();
 		const auto end   = begin + dataunit.length();
 
-		using value_type = decltype(*begin);
-
-		auto e = std::minmax_element(
+		auto e = std::accumulate(
 			begin, end,
+			std::make_pair(std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest()),
+			[](const std::pair<T, T>& acc, const T& element) {
 #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
-			[](value_type x, value_type y) { return swap_bytes(x) < swap_bytes(y); }
+				const T& x = swap_bytes(element);
 #else
-			[](value_type x, value_type y) { return x < y; }
+				const T& x = element;
 #endif
+				return std::make_pair(Utils::min(acc.first, x), Utils::max(acc.second, x));
+			}
 		);
-#if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
-		return std::make_pair(hdu.FITSToInstrumental(swap_bytes(*(e.first))), hdu.FITSToInstrumental(swap_bytes(*(e.second))));
-#else
-		return std::make_pair(hdu.FITSToInstrumental(*(e.first)), hdu.FITSToInstrumental(*(e.second)));
-#endif
+		// Swap max and lowest if data contains only NaNs
+		if (e.first > e.second) {
+			std::swap(e.first, e.second);
+		}
+
+		return std::make_pair(hdu.FITSToInstrumental(e.first), hdu.FITSToInstrumental(e.second));
 	}
 
 	template<class T>

--- a/include/abstractopenglplan.h
+++ b/include/abstractopenglplan.h
@@ -87,8 +87,6 @@ private:
 protected:
 	template<class T>
 	static inline std::pair<double, double> makeMinMax(const FITS::HeaderDataUnit<FITS::DataUnit<T>>& hdu) {
-		using Utils::swap_bytes;
-
 		const auto& dataunit = hdu.data();
 
 		const auto begin = dataunit.data();
@@ -99,7 +97,7 @@ protected:
 			std::make_pair(std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest()),
 			[](const std::pair<T, T>& acc, const T& element) {
 #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
-				const T& x = swap_bytes(element);
+				const T& x = Utils::swap_bytes(element);
 #else
 				const T& x = element;
 #endif

--- a/include/utils/minmax.h
+++ b/include/utils/minmax.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2017  Matwey V. Kornilov <matwey.kornilov@gmail.com>
+ *                      Konstantin Malanchev <hombit@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or (at
+ *  your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _MINMAX_H_
+#define _MINMAX_H_
+
+#include <algorithm> // std::min, std::max
+#include <cmath> // std::fmin, std::fmax
+#include <type_traits> // std::enable_if, std::is_integral, std::is_floating_point
+
+namespace Utils {
+template<class T, typename std::enable_if<std::is_integral<T>::value, bool>::type = 0>
+const T& min(const T& x, const T& y) {
+	return std::min(x, y);
+}
+
+template<class T, typename std::enable_if<std::is_floating_point<T>::value, bool>::type = 0>
+T min(const T& x, const T& y) {
+	return std::fmin(x, y);
+}
+
+template<class T, typename std::enable_if<std::is_integral<T>::value, bool>::type = 0>
+const T& max(const T& x, const T& y) {
+	return std::max(x, y);
+}
+
+template<class T, typename std::enable_if<std::is_floating_point<T>::value, bool>::type = 0>
+T max(const T& x, const T& y) {
+	return std::fmax(x, y);
+}
+} // namespace Utils
+
+#endif //_MINMAX_H_

--- a/test/utils/minmax.cpp
+++ b/test/utils/minmax.cpp
@@ -1,0 +1,93 @@
+#include <cmath>
+#include <limits>
+#include <QtTest/QtTest>
+#include <utils/minmax.h>
+
+class TestMinMax: public QObject
+{
+	Q_OBJECT
+private slots:
+	void min8();
+	void min32_signed();
+	void min32_float();
+	void min64_float();
+	void max8();
+	void max32_signed();
+	void max32_float();
+	void max64_float();
+};
+
+void TestMinMax::min8() {
+	quint8 a = 0;
+	quint8 b = 1;
+	QCOMPARE(Utils::min(a, b), a);
+	QCOMPARE(Utils::min(b, a), a);
+}
+
+void TestMinMax::min32_signed() {
+	qint32 a = 0;
+	qint32 b = 1;
+	QCOMPARE(Utils::min(a, b), a);
+	QCOMPARE(Utils::min(b, a), a);
+}
+
+void TestMinMax::min32_float() {
+	float a = 0;
+	float b = 1;
+	float nan = NAN;
+	QCOMPARE(Utils::min(a, b), a);
+	QCOMPARE(Utils::min(b, a), a);
+	QCOMPARE(Utils::min(a, nan), a);
+	QCOMPARE(Utils::min(nan, a), a);
+	QVERIFY(std::isnan(Utils::min(nan, nan)));
+}
+
+void TestMinMax::min64_float() {
+	double a = 0;
+	double b = 1;
+	double nan = NAN;
+	QCOMPARE(Utils::min(a, b), a);
+	QCOMPARE(Utils::min(b, a), a);
+	QCOMPARE(Utils::min(a, nan), a);
+	QCOMPARE(Utils::min(nan, a), a);
+	QVERIFY(std::isnan(Utils::min(nan, nan)));
+}
+
+void TestMinMax::max8() {
+	quint8 a = 1;
+	quint8 b = 0;
+	QCOMPARE(Utils::max(a, b), a);
+	QCOMPARE(Utils::max(b, a), a);
+}
+
+void TestMinMax::max32_signed() {
+	qint32 a = 1;
+	qint32 b = 0;
+	QCOMPARE(Utils::max(a, b), a);
+	QCOMPARE(Utils::max(b, a), a);
+}
+
+void TestMinMax::max32_float() {
+	float a = 1;
+	float b = 0;
+	float nan = std::numeric_limits<float>::quiet_NaN();
+	QCOMPARE(Utils::max(a, b), a);
+	QCOMPARE(Utils::max(b, a), a);
+	QCOMPARE(Utils::max(a, nan), a);
+	QCOMPARE(Utils::max(nan, a), a);
+	QVERIFY(std::isnan(Utils::max(nan, nan)));
+}
+
+void TestMinMax::max64_float() {
+	double a = 1;
+	double b = 0;
+	double nan = std::numeric_limits<double>::quiet_NaN();
+	QCOMPARE(Utils::max(a, b), a);
+	QCOMPARE(Utils::max(b, a), a);
+	QCOMPARE(Utils::max(a, nan), a);
+	QCOMPARE(Utils::max(nan, a), a);
+	QVERIFY(std::isnan(Utils::max(nan, nan)));
+}
+
+QTEST_MAIN(TestMinMax)
+#include "minmax.moc"


### PR DESCRIPTION
Fix #128: find min and max values ignoring NaN

Check this GUI features before merge:

- [x] Positive and negative `BITPIX` images
- [x] Zoom, rotate and flip
- [x] Level control
- [x] Color maps
- [x] Open new image in the same window and in new window
