### PR TITLE
Introduce HeaderUnit::count()

### DIFF
--- a/include/fits.h
+++ b/include/fits.h
@@ -81,6 +81,10 @@ public:
 
 		static HeaderUnit createFromPages(AbstractFITSStorage::Page& begin, AbstractFITSStorage::Page end);
 
+		inline std::size_t count(const QString& key) const {
+			return headers_.count(key);
+		}
+
 		inline const QString& header(const QString& key) const {
 			return headers_.at(key);
 		}

--- a/test/fits.cpp
+++ b/test/fits.cpp
@@ -23,6 +23,7 @@ private slots:
 	void header2();
 	void header_as1();
 	void header_as2();
+	void count1();
 };
 
 void TestFits::pageAdvance1() {
@@ -191,6 +192,14 @@ void TestFits::header_as2() {
 	QVERIFY_EXCEPTION_THROWN(
 		fits.header_unit().header_as<int>("SIMPLE"),
 		FITS::WrongHeaderValue);
+}
+void TestFits::count1() {
+	QFile* file = new QFile(DATA_ROOT "/header_end.fits");
+	file->open(QIODevice::ReadOnly);
+	FITS fits(file);
+
+	QCOMPARE(fits.header_unit().count("NAXIS2"), std::size_t(1));
+	QCOMPARE(fits.header_unit().count("NAXIS3"), std::size_t(0));
 }
 
 QTEST_MAIN(TestFits)


### PR DESCRIPTION
HeaderUnit::count() semantics is the same as for std::map::count().

Check this GUI features before merge:

- [ ] Positive and negative `BITPIX` images
- [ ] Zoom, rotate and flip
- [ ] Level control
- [ ] Color maps
- [ ] Open new image in the same window and in new window


Cast @aalexr 