### PR TITLE
Fix Exception::what()

### DIFF
--- a/include/utils/exception.h
+++ b/include/utils/exception.h
@@ -20,13 +20,14 @@
 #define _EXCEPTION_H_
 
 #include <QException>
+#include <QByteArray>
 #include <QString>
 
 namespace Utils {
 
 class Exception : public QException {
 private:
-	QString what_;
+	QByteArray what_;
 public:
 	explicit Exception(const QString& what);
 

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -20,7 +20,7 @@
 
 namespace Utils {
 
-Exception::Exception(const QString& what): what_(what) {
+Exception::Exception(const QString& what): what_(what.toLatin1()) {
 }
 
 void Exception::raise() const {
@@ -32,7 +32,7 @@ QException* Exception::clone() const {
 }
 
 const char* Exception::what() const noexcept {
-	return what_.toLatin1().constData();
+	return what_.constData();
 }
 
 } //Utils


### PR DESCRIPTION
Before this PR, `Exception::what()` was returning an address taken from a temporary object.
